### PR TITLE
SPRESENSE Wi-SUN: Fix compile and hardfault errors

### DIFF
--- a/KX122/KX122.cpp
+++ b/KX122/KX122.cpp
@@ -80,6 +80,8 @@ byte KX122::init(void)
     case KX122_CNTL1_GSEL_8G : _g_sens = 4096;  break;
     default: break;
   }
+
+  return (rc);
 }
 
 byte KX122::get_rawval(unsigned char *data)

--- a/SPRESENSE-WISUN-EVK-701/bp35c0-j11.cpp
+++ b/SPRESENSE-WISUN-EVK-701/bp35c0-j11.cpp
@@ -20,7 +20,7 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 *********************************************************************************/
-#include <arduino.h>
+#include <Arduino.h>
 #include "bp35c0-j11.h"
 
 unsigned const char uni_req[4] = {0xD0 , 0xEA , 0x83 , 0xFC};

--- a/SPRESENSE-WISUN-EVK-701/bp35c0-j11.cpp
+++ b/SPRESENSE-WISUN-EVK-701/bp35c0-j11.cpp
@@ -213,7 +213,6 @@ boolean BP35C0J11::cmd_send(unsigned short cmd) {
   unsigned char data[128] = {0};
 
   unsigned char send_data[128] = {0} ;
-  boolean rc = FALSE;
   unsigned char cnt = 0 ;
 
   switch (cmd) {
@@ -352,6 +351,8 @@ boolean BP35C0J11::cmd_send(unsigned short cmd) {
 
       break;
   }
+
+  return TRUE;
 }
 
 /********************************************************************************


### PR DESCRIPTION
* Fix compile error in case-sensitive environment
* Fix hardfault error by return-type missing
